### PR TITLE
Property type considers secondary object types and fix for multivalued properties

### DIFF
--- a/atom/cmis/cmis_service.php
+++ b/atom/cmis/cmis_service.php
@@ -203,22 +203,23 @@ class CMISService extends CMISRepositoryWrapper {
 			}
 		}
 		$obj = $this->getTypeDefinition($typeId);
-    if (isset($obj->properties[$propertyId])) {
-		    return $obj->properties[$propertyId]["cmis:propertyType"];
-    }
-
-    foreach ($secondaryTypeIds as $secondaryId){
-      if (isset($this->_type_cache[$secondaryId])) {
-        if (isset($this->_type_cache[$secondaryId]->properties[$propertyId])) {
-          return $this->_type_cache[$secondaryId]->properties[$propertyId]["cmis:propertyType"];
+        
+        if (isset($obj->properties[$propertyId])) {
+    		    return $obj->properties[$propertyId]["cmis:propertyType"];
         }
-      }
-      $obj = $this->getTypeDefinition($secondaryId);
-      if (isset($obj->properties[$propertyId])) {
-          return $obj->properties[$propertyId]["cmis:propertyType"];
-      }
-    }
-    return false;
+
+        foreach ($secondaryTypeIds as $secondaryId){
+          if (isset($this->_type_cache[$secondaryId])) {
+            if (isset($this->_type_cache[$secondaryId]->properties[$propertyId])) {
+              return $this->_type_cache[$secondaryId]->properties[$propertyId]["cmis:propertyType"];
+            }
+          }
+          $obj = $this->getTypeDefinition($secondaryId);
+          if (isset($obj->properties[$propertyId])) {
+              return $obj->properties[$propertyId]["cmis:propertyType"];
+          }
+        }
+        return false;
 	}
 
 	/**
@@ -846,11 +847,11 @@ EOT;
 			$hash_values["cmis:objectTypeId"]=$objectType;
 		}
 
-    if (isset($hash_values["cmis:secondaryObjectTypeIds"]) && is_array($hash_values["cmis:secondaryObjectTypeIds"])) {
-      $secondaryTypeIds = $hash_values["cmis:secondaryObjectTypeIds"];
-    } else {
-      $secondaryTypeIds = array();
-    }
+        if (isset($hash_values["cmis:secondaryObjectTypeIds"]) && is_array($hash_values["cmis:secondaryObjectTypeIds"])) {
+          $secondaryTypeIds = $hash_values["cmis:secondaryObjectTypeIds"];
+        } else {
+          $secondaryTypeIds = array();
+        }
 
 		$properties_xml = $this->processPropertyTemplates($objectType, $secondaryTypeIds, $hash_values);
 
@@ -894,11 +895,11 @@ EOT;
 		//DEBUG
 		//print("DEBUG: postEntry: myURL = " . $myURL);
 
-    if (isset($properties["cmis:secondaryObjectTypeIds"]) && is_array($properties["cmis:secondaryObjectTypeIds"])) {
-      $secondaryTypeIds = $properties["cmis:secondaryObjectTypeIds"];
-    } else {
-      $secondaryTypeIds = array();
-    }
+        if (isset($properties["cmis:secondaryObjectTypeIds"]) && is_array($properties["cmis:secondaryObjectTypeIds"])) {
+          $secondaryTypeIds = $properties["cmis:secondaryObjectTypeIds"];
+        } else {
+          $secondaryTypeIds = array();
+        }
 
 		$properties_xml = $this->processPropertyTemplates($objType, $secondaryTypeIds, $properties);
 		//print("DEBUG: postEntry: properties_xml = " . $properties_xml);
@@ -957,11 +958,11 @@ EOT;
 			$properties['cmis:changeToken'] = $this->_changeToken_cache[$objectId];
 		}
 
-    if (isset($properties["cmis:secondaryObjectTypeIds"]) && is_array($properties["cmis:secondaryObjectTypeIds"])) {
-      $secondaryTypeIds = $properties["cmis:secondaryObjectTypeIds"];
-    } else {
-      $secondaryTypeIds = array();
-    }
+        if (isset($properties["cmis:secondaryObjectTypeIds"]) && is_array($properties["cmis:secondaryObjectTypeIds"])) {
+          $secondaryTypeIds = $properties["cmis:secondaryObjectTypeIds"];
+        } else {
+          $secondaryTypeIds = array();
+        }
 
 		$properties_xml = $this->processPropertyTemplates($objectType, $secondaryTypeIds, $hash_values);
 

--- a/atom/cmis/cmis_service.php
+++ b/atom/cmis/cmis_service.php
@@ -627,7 +627,7 @@ EOT;
 	private static function getPropertyTemplate() {
 		return "
 		<cmis:property{propertyType} propertyDefinitionId=\"{propertyId}\">
-			<cmis:value>{properties}</cmis:value>
+			{properties}
 		</cmis:property{propertyType}>
 		";
 	}
@@ -658,12 +658,13 @@ EOT;
 			$hash_values['propertyType'] = $propertyTypeMap[$this->getPropertyType($objectType, $propId)];
 			$hash_values['propertyId']   = $propId;
 			if (is_array($propValue)) {
+				$hash_values['properties'] = '';
 				foreach ($propValue as $val) {
-                    $hash_values['properties'].= sprintf('<cmis:value>%s</cmis:value>', $val);
+          			$hash_values['properties'].= sprintf('<cmis:value>%s</cmis:value>', $val);
 				}
 			}
 			else {
-				$hash_values['properties'] = $propValue;
+				$hash_values['properties'] = sprintf('<cmis:value>%s</cmis:value>', $propValue);
 			}
 			$propertyContent .= parent::processTemplate(self::getPropertyTemplate(), $hash_values);
 		}


### PR DESCRIPTION
Two changes.
1. The private method  getPropertyType takes an additional parameter. Secondary types are now taken into consideration. this has been changed in 3 calls to this method.
2. Multi valued parameters were not set correctly, this was due to each value begin placed in a value element, and then all of these being placed in one by the template:
   i.e.

```
<value>
    <value>a</value>
    <value>b</value>
    <value>c</value>
</value>
```

The additional value element containg all other values.
