### PR TITLE
Set options for HTTP PUT request, fixed comparision of curl exec

### DIFF
--- a/atom/cmis/cmis_repository_wrapper.php
+++ b/atom/cmis/cmis_repository_wrapper.php
@@ -248,6 +248,7 @@ class CMISRepositoryWrapper
         if ($contentType)      { curl_setopt($session, CURLOPT_HTTPHEADER, array ("Content-Type: " . $contentType)); }
         if ($content)          { curl_setopt($session, CURLOPT_POSTFIELDS, $content); }
         if ($method == "POST") { curl_setopt($session, CURLOPT_POST,       true); }
+        if ($method == "PUT")  { curl_setopt($session, CURLOPT_POST,       true); }
 
         // apply addl. cURL options
         // WARNING: this may override previously set options
@@ -259,7 +260,7 @@ class CMISRepositoryWrapper
 
         //TODO: Make this storage optional
         $response = curl_exec($session);
-        if ($response) {
+        if ($response !== false) {
 			$retval = new stdClass();
 			$retval->url               = $url;
 			$retval->method            = $method;


### PR DESCRIPTION
Hello again,

two small fixes this time, both to the "atom/cmis/cmis_repository_wrapper.php" doRequest()
- When making a PUT request the CURLOPT_POST is set to true, This is done for POST request and PUT requests function similarly. (Though it is not form encoded data, so this is not important and maybe should not be set for either?)
-  More importantly: changed the check on response to check type as well. i.e. $response !== false.
  Alfresco returns an empty string as response to an setContentStream call. 
  This empty string can be evaluated as false if type is not checked
